### PR TITLE
Fix bad error checking on setNewPassword

### DIFF
--- a/src/Models/Account.js
+++ b/src/Models/Account.js
@@ -310,14 +310,12 @@ class Account {
             },
         });
 
-        if (response.status >= 200 && response.status <= 300) {
-            return {
-                code: response.status,
-                message: 'The password has been successfully changed.',
-            };
-        }
+        checkStatus(response);
 
-        return await response.json();
+        return {
+            code: response.status,
+            message: 'The password has been successfully changed.',
+        };
     }
 
     /**


### PR DESCRIPTION
Use `checkStatus` for checking errors instead of manually checking the status code in setNewPassword.