### PR TITLE
refreshToken function parameter clientId must be a string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Changes
 
 - Add string type to clientId parameter in refreshToken function
-- Add missing express property to the CreateAccout interface
+- Add missing expires property to the CreateAccout interface
 
 # [3.0.0-beta.3] - 20-12-2019
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changes
 
-- Add missing type string to clientId parameter in refreshToken function
+- Add string type to clientId parameter in refreshToken function
 - Add missing express property to the CreateAccout interface
 
 # [3.0.0-beta.3] - 20-12-2019

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+# [3.0.0-beta.4] - 13-01-2020
+
+### Add
+
+- Add missing type string to clientId parameter in refreshToken function
+- Add missing express property to the CreateAccout interface
+
 # [3.0.0-beta.3] - 20-12-2019
 
 ### Add

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 # [3.0.0-beta.4] - 13-01-2020
 
-### Add
+### Changes
 
 - Add missing type string to clientId parameter in refreshToken function
 - Add missing express property to the CreateAccout interface

--- a/src/endpoints/account.ts
+++ b/src/endpoints/account.ts
@@ -175,7 +175,7 @@ class Account extends BaseExtend {
    *     InPlayer.Account.refreshToken('123123121-d1-t1-1ff').then(data => console.log(data))
    * @returns  {AxiosResponse<CreateAccount>}
    */
-  async refreshToken(clientId: number | string) {
+  async refreshToken(clientId: string) {
     const token = this.request.getToken();
 
     if (!token.refreshToken) {

--- a/src/endpoints/account.ts
+++ b/src/endpoints/account.ts
@@ -175,7 +175,7 @@ class Account extends BaseExtend {
    *     InPlayer.Account.refreshToken('123123121-d1-t1-1ff').then(data => console.log(data))
    * @returns  {AxiosResponse<CreateAccount>}
    */
-  async refreshToken(clientId: number) {
+  async refreshToken(clientId: number | string) {
     const token = this.request.getToken();
 
     if (!token.refreshToken) {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -92,6 +92,7 @@ export declare interface CreateAccount {
   access_token: string;
   refresh_token: string;
   account: AccountInformationReturn;
+  expires: string;
 }
 
 export declare interface CommonResponse {
@@ -139,7 +140,7 @@ export declare class Account {
   signIn(data: AuthenticateData): Promise<AxiosResponse<CreateAccount>>;
   signUp(data: SignUpData): Promise<AxiosResponse<CreateAccount>>;
   signOut(): Promise<AxiosResponse<undefined>>;
-  refreshToken(clientId: number): Promise<AxiosResponse<CreateAccount>>;
+  refreshToken(clientId: number | string): Promise<AxiosResponse<CreateAccount>>;
   reportSSOtoken(
     ssoDomain: string,
     token: string,

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -140,7 +140,7 @@ export declare class Account {
   signIn(data: AuthenticateData): Promise<AxiosResponse<CreateAccount>>;
   signUp(data: SignUpData): Promise<AxiosResponse<CreateAccount>>;
   signOut(): Promise<AxiosResponse<undefined>>;
-  refreshToken(clientId: number | string): Promise<AxiosResponse<CreateAccount>>;
+  refreshToken(clientId: string): Promise<AxiosResponse<CreateAccount>>;
   reportSSOtoken(
     ssoDomain: string,
     token: string,

--- a/src/models/IAccount&Authentication.ts
+++ b/src/models/IAccount&Authentication.ts
@@ -28,7 +28,7 @@ export interface Account extends BaseExtend {
   signIn(data: AuthenticateData): Promise<AxiosResponse<CreateAccount>>;
   signUp(data: SignUpData): Promise<AxiosResponse<CreateAccount>>;
   signOut(): Promise<AxiosResponse<undefined>>;
-  refreshToken(clientId: number): Promise<AxiosResponse<CreateAccount>>;
+  refreshToken(clientId: number | string): Promise<AxiosResponse<CreateAccount>>;
   reportSSOtoken(
     ssoDomain: string,
     tokenData: Credentials,
@@ -76,6 +76,7 @@ export interface CreateAccount {
   access_token: string;
   refresh_token: string;
   account: AccountInformationReturn;
+  expires: string;
 }
 
 export interface Follower {

--- a/src/models/IAccount&Authentication.ts
+++ b/src/models/IAccount&Authentication.ts
@@ -28,7 +28,7 @@ export interface Account extends BaseExtend {
   signIn(data: AuthenticateData): Promise<AxiosResponse<CreateAccount>>;
   signUp(data: SignUpData): Promise<AxiosResponse<CreateAccount>>;
   signOut(): Promise<AxiosResponse<undefined>>;
-  refreshToken(clientId: number | string): Promise<AxiosResponse<CreateAccount>>;
+  refreshToken(clientId: string): Promise<AxiosResponse<CreateAccount>>;
   reportSSOtoken(
     ssoDomain: string,
     tokenData: Credentials,


### PR DESCRIPTION
## OVERVIEW

_Add type string to clientId function parameter. Add missing expires property to the CreateAccout interface_

## WHERE SHOULD THE REVIEWER START?

_`/src/endpoints/account.ts`_
_`src/index.d.ts`_
_`src/models/IAccount&Authentication.ts`_

## ANY NEW DEPENDENCIES ADDED?

_List any new dependencies added._

- [ ] Does it work in IE >= 11?
- [ ] _Does it work in other browsers?_

## CHECKLIST

_Be sure all items are_ ✅ _before submitting a PR for review._

- [ ] Verify you bumped the lib version according to [Semantic Versioning Standards](http://semver.org)
- [ ] Verify you updated the CHANGELOG
- [ ] Verify this branch is rebased with the latest master
