### PR TITLE
added uuid and merchant_uuid as missing props in AccountInformationRe…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+# [3.0.0-beta.8] - 23-05-2020
+
+### Added
+
+- Add missing props `uuid` and `merchant_uuid` in interface `AccountInformationReturn`
+
 # [3.0.0-beta.7] - 18-05-2020
 
 ### Changes

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -86,6 +86,7 @@ export declare interface AccountInformationReturn {
   created_at: number;
   updated_at: number;
   uuid: string;
+  merchant_uuid: string;
 }
 
 export declare interface CreateAccount {

--- a/src/models/IAccount&Authentication.ts
+++ b/src/models/IAccount&Authentication.ts
@@ -70,6 +70,8 @@ export interface AccountInformationReturn {
   completed: boolean;
   created_at: number;
   updated_at: number;
+  uuid: string;
+  merchant_uuid: string;
 }
 
 export interface CreateAccount {


### PR DESCRIPTION
…turn interface

## OVERVIEW

_Props `uuid` and `merchant_uuid` were missing in interface `AccountInformationReturn`._

## WHERE SHOULD THE REVIEWER START?

_e.g. `/src/index.d.ts`_

## CHECKLIST

_Be sure all items are_ ✅ _before submitting a PR for review._

- [x] Verify you bumped the lib version according to [Semantic Versioning Standards](http://semver.org)
- [x] Verify you updated the CHANGELOG
- [x] Verify this branch is rebased with the latest master
