### PR TITLE
Added param `product_name` to Payment.validateReceipt() method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+# [3.4.1] - 02-11-2020
+
+### Added
+
+- New optional parameter `product_name` to Payment.validatePayment method
+
 # [3.4.0] - 30-10-2020
 
 ### Added

--- a/index.d.ts
+++ b/index.d.ts
@@ -624,13 +624,37 @@ export enum ReceiptValidationPlatform {
   ROKU = 'roku',
 }
 
-export interface ValidateReceiptData {
+interface AmazonPlatformData {
+  platform: ReceiptValidationPlatform.AMAZON;
+  receipt: string;
+  amazonUserId: string;
+}
+
+interface NonAmazonPlatformData {
+  platform: Omit<ReceiptValidationPlatform, ReceiptValidationPlatform.AMAZON>;
+  receipt: string;
+  amazonUserId?: never;
+}
+
+type CommonPlatformData = AmazonPlatformData | NonAmazonPlatformData;
+
+interface ReceiptDataWithProductName {
+  productName: string;
+  itemId?: never;
+  accessFeeId?: never;
+}
+
+interface ReceiptDataWithItemIdAndAccessFeeId {
   itemId: number;
   accessFeeId: number;
-  receipt: string;
-  platform: ReceiptValidationPlatform;
-  amazonUserId?: string;
+  productName?: never;
 }
+
+type ReceiptData =
+  | ReceiptDataWithProductName
+  | ReceiptDataWithItemIdAndAccessFeeId;
+
+export type ValidateReceiptData = CommonPlatformData & ReceiptData;
 
 export declare class Payment {
   constructor(config: Record<string, unknown>, Account: Account);

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-import { AxiosResponse } from "axios";
+import { AxiosResponse } from 'axios';
 
 /* eslint-disable camelcase */
 export interface CredentialsConfig {

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-import { AxiosResponse } from 'axios';
+import { AxiosResponse } from "axios";
 
 /* eslint-disable camelcase */
 export interface CredentialsConfig {
@@ -626,25 +626,25 @@ export enum ReceiptValidationPlatform {
 
 interface AmazonPlatformData {
   platform: ReceiptValidationPlatform.AMAZON;
-  receipt: string;
   amazonUserId: string;
 }
 
 interface NonAmazonPlatformData {
   platform: Omit<ReceiptValidationPlatform, ReceiptValidationPlatform.AMAZON>;
-  receipt: string;
   amazonUserId?: never;
 }
 
 type CommonPlatformData = AmazonPlatformData | NonAmazonPlatformData;
 
 interface ReceiptDataWithProductName {
+  receipt: string;
   productName: string;
   itemId?: never;
   accessFeeId?: never;
 }
 
 interface ReceiptDataWithItemIdAndAccessFeeId {
+  receipt: string;
   itemId: number;
   accessFeeId: number;
   productName?: never;

--- a/index.d.ts
+++ b/index.d.ts
@@ -630,7 +630,7 @@ interface AmazonPlatformData {
 }
 
 interface NonAmazonPlatformData {
-  platform: Omit<ReceiptValidationPlatform, ReceiptValidationPlatform.AMAZON>;
+  platform: Exclude<ReceiptValidationPlatform, ReceiptValidationPlatform.AMAZON>;
   amazonUserId?: never;
 }
 

--- a/src/endpoints/payment.ts
+++ b/src/endpoints/payment.ts
@@ -9,6 +9,7 @@ import {
   IdealPaymentData,
   IdealPaymentRequestBody,
   ValidateReceiptData,
+  ReceiptValidationPlatform,
 } from '../models/IPayment&Subscription';
 import { CustomErrorResponse } from '../models/CommonInterfaces';
 import { ApiConfig, Request } from '../models/Config';
@@ -696,17 +697,23 @@ class Payment extends BaseExtend {
    *  }
    */
   async validateReceipt({
-    platform, itemId, accessFeeId, receipt, amazonUserId,
+    platform,
+    receipt,
+    productName: product_name,
+    itemId: item_id,
+    accessFeeId: access_fee_id,
+    amazonUserId: amazon_user_id,
   }: ValidateReceiptData) {
     const body = {
-      item_id: itemId,
-      access_fee_id: accessFeeId,
       receipt,
-      ...(amazonUserId ? { amazon_user_id: amazonUserId } : {}),
+      ...(product_name ? { product_name } : { item_id, access_fee_id }),
+      ...(platform === ReceiptValidationPlatform.AMAZON
+        ? { amazon_user_id }
+        : {}),
     };
 
     return this.request.authenticatedPost(
-      API.validateReceipt(platform),
+      API.validateReceipt(String(platform)),
       qs.stringify(body),
       {
         headers: {

--- a/src/models/IPayment&Subscription.ts
+++ b/src/models/IPayment&Subscription.ts
@@ -481,25 +481,25 @@ export enum ReceiptValidationPlatform {
 
 interface AmazonPlatformData {
   platform: ReceiptValidationPlatform.AMAZON;
-  receipt: string;
   amazonUserId: string;
 }
 
 interface NonAmazonPlatformData {
   platform: Omit<ReceiptValidationPlatform, ReceiptValidationPlatform.AMAZON>;
-  receipt: string;
   amazonUserId?: never;
 }
 
 type CommonPlatformData = AmazonPlatformData | NonAmazonPlatformData;
 
 interface ReceiptDataWithProductName {
+  receipt: string;
   productName: string;
   itemId?: never;
   accessFeeId?: never;
 }
 
 interface ReceiptDataWithItemIdAndAccessFeeId {
+  receipt: string;
   itemId: number;
   accessFeeId: number;
   productName?: never;

--- a/src/models/IPayment&Subscription.ts
+++ b/src/models/IPayment&Subscription.ts
@@ -472,20 +472,44 @@ export interface IdealPaymentRequestBody {
   voucher_code?: string;
 }
 
-enum ReceiptValidationPlatform {
+export enum ReceiptValidationPlatform {
   AMAZON = 'amazon',
   APPLE = 'apple',
   GOOGLE_PLAY = 'google-play',
   ROKU = 'roku',
 }
 
-export interface ValidateReceiptData {
+interface AmazonPlatformData {
+  platform: ReceiptValidationPlatform.AMAZON;
+  receipt: string;
+  amazonUserId: string;
+}
+
+interface NonAmazonPlatformData {
+  platform: Omit<ReceiptValidationPlatform, ReceiptValidationPlatform.AMAZON>;
+  receipt: string;
+  amazonUserId?: never;
+}
+
+type CommonPlatformData = AmazonPlatformData | NonAmazonPlatformData;
+
+interface ReceiptDataWithProductName {
+  productName: string;
+  itemId?: never;
+  accessFeeId?: never;
+}
+
+interface ReceiptDataWithItemIdAndAccessFeeId {
   itemId: number;
   accessFeeId: number;
-  receipt: string;
-  platform: ReceiptValidationPlatform;
-  amazonUserId?: string;
+  productName?: never;
 }
+
+type ReceiptData =
+  | ReceiptDataWithProductName
+  | ReceiptDataWithItemIdAndAccessFeeId;
+
+export type ValidateReceiptData = CommonPlatformData & ReceiptData;
 
 export interface Payment extends BaseExtend {
   getPaymentMethods(): Promise<AxiosResponse<MerchantPaymentMethod[]>>;

--- a/src/models/IPayment&Subscription.ts
+++ b/src/models/IPayment&Subscription.ts
@@ -485,7 +485,7 @@ interface AmazonPlatformData {
 }
 
 interface NonAmazonPlatformData {
-  platform: Omit<ReceiptValidationPlatform, ReceiptValidationPlatform.AMAZON>;
+  platform: Exclude<ReceiptValidationPlatform, ReceiptValidationPlatform.AMAZON>;
   amazonUserId?: never;
 }
 


### PR DESCRIPTION
## OVERVIEW

Added an optional param `product_name` to Payment.validateReceipt() method.

## WHERE SHOULD THE REVIEWER START?

_e.g. `/src/endpoints/payment.ts`_

## CHECKLIST

_Be sure all items are_ ✅ _before submitting a PR for review._

- [x] Verify you bumped the lib version according to [Semantic Versioning Standards](http://semver.org)
- [x] Verify you updated the CHANGELOG
- [x] Verify this branch is rebased with the latest master
