### PR TITLE
Removed gift params from createSubscription method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+# [3.6.3] - 22-12-2020
+
+### Changes
+
+- Removed isGift and receiverEmail params from Subscription.createSubscription method
+
 # [3.6.2]
 
 ### Fixes

--- a/index.d.ts
+++ b/index.d.ts
@@ -721,8 +721,6 @@ export interface CreateSubscriptionData {
   voucherCode?: string;
   brandingId?: number;
   returnUrl: string;
-  receiverEmail?: string;
-  isGift?: boolean;
 }
 
 export declare interface SubscriptionDetails {

--- a/src/endpoints/subscription.ts
+++ b/src/endpoints/subscription.ts
@@ -98,8 +98,6 @@ class Subscription extends BaseExtend {
    *  voucherCode?: string
    *  brandingId?: number
    *  returnUrl?: string
-   *  isGift?: string,
-   *  receiverEmail?: string,
    * }
    * @example
    *     InPlayer.Subscription
@@ -136,11 +134,6 @@ class Subscription extends BaseExtend {
 
     if (data.voucherCode) {
       body.voucher_code = data.voucherCode;
-    }
-
-    if (data.isGift) {
-      body.is_gift = data.isGift;
-      body.receiver_email = data.receiverEmail;
     }
 
     return this.request.authenticatedPost(

--- a/src/models/IPayment&Subscription.ts
+++ b/src/models/IPayment&Subscription.ts
@@ -330,8 +330,6 @@ export interface CreateSubscriptionData {
   voucherCode?: string;
   brandingId?: number;
   returnUrl: string;
-  receiverEmail?: string;
-  isGift?: boolean;
 }
 
 export interface CreateSubscriptionRequestBody {


### PR DESCRIPTION
## OVERVIEW

Removed isGift and receiverEmail params from Subscription.createSubscription method

## WHERE SHOULD THE REVIEWER START?

_e.g. `/src/Models/Account.js`_

## ANY NEW DEPENDENCIES ADDED?

_List any new dependencies added._

- [ ] Does it work in IE >= 11?
- [ ] _Does it work in other browsers?_

## CHECKLIST

_Be sure all items are_ ✅ _before submitting a PR for review._

- [ ] Verify you bumped the lib version according to [Semantic Versioning Standards](http://semver.org)
- [ ] Verify you updated the CHANGELOG
- [ ] Verify this branch is rebased with the latest master
