### PR TITLE
chore: Remove use of authenticatedGet in getDonationOptions method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+# [3.7.1] - 12-01-2021
+
+### Changes
+
+- Remove use of authenticatedGet in getDonationOptions method
+
 # [3.7.0] - 11-01-2021
 
 ### Added

--- a/src/endpoints/asset.ts
+++ b/src/endpoints/asset.ts
@@ -354,7 +354,7 @@ class Asset extends BaseExtend {
    * @returns {AxiosResponse<DonationDetails>}
    */
   async getDonationOptions(assetId: number) {
-    return this.request.authenticatedGet(API.getDonations(assetId), {
+    return this.request.get(API.getDonations(assetId), {
       headers: {
         Authorization: `Bearer ${this.request.getToken().token}`,
       },


### PR DESCRIPTION
## OVERVIEW

Remove use of authenticatedGet in getDonationOptions method

## WHERE SHOULD THE REVIEWER START?

 `/src/endpoints/assets.ts`

## ANY NEW DEPENDENCIES ADDED?

_List any new dependencies added._

- [x] Does it work in IE >= 11?
- [x] _Does it work in other browsers?_

## CHECKLIST

_Be sure all items are_ ✅ _before submitting a PR for review._

- [x] Verify you bumped the lib version according to [Semantic Versioning Standards](http://semver.org)
- [x] Verify you updated the CHANGELOG
- [x] Verify this branch is rebased with the latest master
