### PR TITLE
No issue/versions error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+# [2.13.9] - 26-04-2021
+
+### Fixes
+
+- The same as in v2.13.7. It was republish again due to `Unable to resolve path to module '@inplayer-org/inplayer.js'` error
+
 # [2.13.7] - 26-04-2021
 
 ### Fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inplayer-org/inplayer.js",
-  "version": "2.13.7",
+  "version": "2.13.8",
   "author": "InPlayer",
   "license": "MIT",
   "description": "A Javascript SDK for Inplayer's RESTful API",


### PR DESCRIPTION
## OVERVIEW

_The same as in v2.13.7. It was republish again due to `Unable to resolve path to module '@inplayer-org/inplayer.js'` error._

## WHERE SHOULD THE REVIEWER START?

## ANY NEW DEPENDENCIES ADDED?

_List any new dependencies added._

- [ ] Does it work in IE >= 11?
- [ ] _Does it work in other browsers?_

## CHECKLIST

_Be sure all items are_ ✅ _before submitting a PR for review._

- [ ] Verify you bumped the lib version according to [Semantic Versioning Standards](http://semver.org)
- [ ] Verify you updated the CHANGELOG
- [ ] Verify this branch is rebased with the latest master
