### PR TITLE
The type of getSubscription method parameter changed to string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changes
 
-- The type of getSubscription method parameter chnaged to string
+- The type of getSubscription method parameter changed to string
 
 # [3.12.1] - 03-12-2021
 ## Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+# [3.12.2] - 07-12-2021
+
+### Changes
+
+- The type of getSubscription method parameter chnaged to string
+
 # [3.12.1] - 03-12-2021
 ## Changes
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -859,7 +859,7 @@ export declare class Subscription {
     limit?: number,
     status?: string
   ): Promise<AxiosResponse<GetSubscription>>;
-  getSubscription(id: number): Promise<AxiosResponse<SubscriptionDetails>>;
+  getSubscription(id: string): Promise<AxiosResponse<SubscriptionDetails>>;
   cancelSubscription(
     unsubscribeUrl: string
   ): Promise<AxiosResponse<CancelSubscription>>;
@@ -936,7 +936,7 @@ export interface ApiEndpoints {
   validateReceipt: (platform: string) => string;
   // Subscription
   getSubscriptions: (limit: number, page: number) => string;
-  getSubscription: (id: number) => string;
+  getSubscription: (id: string) => string;
   subscribe: string;
   cancelSubscription: (url: string) => string;
   // Voucher

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -95,7 +95,7 @@ export const API = {
     }
     return url;
   },
-  getSubscription: (id: number): string => `/subscriptions/${id}`,
+  getSubscription: (id: string): string => `/subscriptions/${id}`,
   cancelSubscription: (url: string): string => `${url}`,
   subscribe: '/subscriptions',
   subscribeV2: '/v2/subscriptions',

--- a/src/endpoints/subscription.ts
+++ b/src/endpoints/subscription.ts
@@ -82,7 +82,7 @@ class Subscription extends BaseExtend {
    * @method getSubscription
    * @async
    *
-   * @param {number} id The subscription id.
+   * @param {string} id The subscription id.
    * @example
    *     InPlayer.Subscription
    *     .getSubscription('abcdef')
@@ -106,7 +106,7 @@ class Subscription extends BaseExtend {
    * }
    * ```
    */
-  async getSubscription(id: number): Promise<AxiosResponse<SubscriptionDetails>> {
+  async getSubscription(id: string): Promise<AxiosResponse<SubscriptionDetails>> {
     const tokenObject = await this.request.getToken();
 
     return this.request.authenticatedGet(API.getSubscription(id), {

--- a/src/models/Config.ts
+++ b/src/models/Config.ts
@@ -69,7 +69,7 @@ export interface ApiEndpoints {
   ) => string;
   // Subscriptions
   getSubscriptions: (limit: number, page: number) => string;
-  getSubscription: (id: number) => string;
+  getSubscription: (id: string) => string;
   cancelSubscription: (url: string) => string;
   subscribe: string;
   subscribeV2: string;

--- a/src/models/ISubscription.ts
+++ b/src/models/ISubscription.ts
@@ -124,7 +124,7 @@ export interface Subscription extends BaseExtend {
         page?: number,
         limit?: number
     ): Promise<AxiosResponse<GetSubscription>>;
-    getSubscription(id: number): Promise<AxiosResponse<SubscriptionDetails>>;
+    getSubscription(id: string): Promise<AxiosResponse<SubscriptionDetails>>;
     cancelSubscription(
         unsubscribeUrl: string
     ): Promise<AxiosResponse<CancelSubscription>>;


### PR DESCRIPTION
## OVERVIEW

_Change the type of getSubscription id param from number to string_

## WHERE SHOULD THE REVIEWER START?

_`index.d.ts`_
_`src/constants/index.ts`_
_`src/endpoints/subscription.ts`_
_`src/models/Config.ts`_
_`src/models/ISubscription.ts`_

## ANY NEW DEPENDENCIES ADDED?

_List any new dependencies added._

- [ ] Does it work in IE >= 11?
- [ ] _Does it work in other browsers?_

## CHECKLIST

_Be sure all items are_ ✅ _before submitting a PR for review._

- [ ] Verify you bumped the lib version according to [Semantic Versioning Standards](http://semver.org)
- [ ] Verify you updated the CHANGELOG
- [ ] Verify this branch is rebased with the latest master
