### PR TITLE
New Subscribe method that changes the subscription plan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
 # Change Log
 
 All notable changes to this project will be documented in this file.
+# [3.12.5] - 03-17-2022
 
+### Changes
+
+- Add new method in Subscription that changes the subscription plan. The change can either a downgrade or an upgrade.
 # [3.12.4] - 03-17-2022
 
 ### Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ All notable changes to this project will be documented in this file.
 
 ### Changes
 
-- Add new method in Subscription that changes the subscription plan. The change can either a downgrade or an upgrade.
+- Add new method in Subscription that changes the existing subscription plan. The change can either a downgrade or an upgrade.
+
 # [3.12.4] - 03-17-2022
 
 ### Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changes
 
-- Add new method in Subscription that changes the existing subscription plan. The change can either a downgrade or an upgrade.
+- Add new method in Subscription that changes the existing subscription plan. The change can either be a downgrade or an upgrade.
 
 # [3.12.4] - 03-17-2022
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -850,6 +850,15 @@ export declare interface CancelSubscription {
   status: string;
   timestamp: number;
 }
+
+export interface ChangeSubscriptionPlanRequestBody {
+  access_fee_id: number;
+  inplayer_token: string;
+}
+
+export interface ChangeSubscriptionPlanResponse {
+  message: string;
+}
 export declare class Subscription {
   // eslint-disable-next-line no-shadow
   constructor(config: Record<string, unknown>, Account: Account);
@@ -866,6 +875,9 @@ export declare class Subscription {
   createSubscription(
     data: CreateSubscriptionData
   ): Promise<AxiosResponse<CommonResponse>>;
+  changeSubscriptionPlan(
+    data: ChangeSubscriptionPlanRequestBody
+): Promise<AxiosResponse<ChangeSubscriptionPlanResponse>>;
 }
 
 export interface DiscountData {
@@ -939,6 +951,7 @@ export interface ApiEndpoints {
   getSubscription: (id: string) => string;
   subscribe: string;
   cancelSubscription: (url: string) => string;
+  changeSubscriptionPlan: (accessFeeId: number, inplayerToken: string) => string;
   // Voucher
   getDiscount: string;
   // Branding

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inplayer-org/inplayer.js",
-  "version": "3.12.4",
+  "version": "3.12.5",
   "author": "InPlayer",
   "license": "MIT",
   "description": "A Javascript SDK for Inplayer's RESTful API",

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -99,6 +99,7 @@ export const API = {
   cancelSubscription: (url: string): string => `${url}`,
   subscribe: '/subscriptions',
   subscribeV2: '/v2/subscriptions',
+  subscriptionPlanChange: '/v2/subscriptions/stripe:switch',
 
   // Vouchers
   getDiscount: '/vouchers/discount',

--- a/src/endpoints/subscription.ts
+++ b/src/endpoints/subscription.ts
@@ -8,6 +8,7 @@ import {
   IdealPaymentRequestBody,
   GetDefaultCard,
   SetDefaultCard,
+  ChangeSubscriptionPlanRequestBody,
 } from '../models/ISubscription';
 import { CommonResponse } from '../models/CommonInterfaces';
 import { ApiConfig, Request } from '../models/Config';
@@ -241,6 +242,46 @@ class Subscription extends BaseExtend {
     const tokenObject = await this.request.getToken();
 
     return this.request.authenticatedPost(API.subscribe, qs.stringify(body), {
+      headers: {
+        Authorization: `Bearer ${tokenObject.token}`,
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+    });
+  }
+
+  /**
+   * Changes the subscription plan for a given asset.
+   * @method post
+   * @async
+   * @param {Object} data - {
+   *  access_fee_id: number,
+   *  inplayer_token: number
+   * }
+   * @example
+   *     InPlayer.Subscription
+   *     .changeSubscriptionPlan({
+   *          access_fee_id: 1,
+   *          inplayer_token: S-xxxxx-ST
+   *        }
+   *     )
+   *     .then(data => console.log(data));
+   * @return {Object}
+   */
+  async changeSubscriptionPlan({
+    access_fee_id,
+    inplayer_token,
+  }: {
+    access_fee_id: number,
+    inplayer_token: string,
+   }): Promise<AxiosResponse<CommonResponse>> {
+    const body: ChangeSubscriptionPlanRequestBody = {
+      access_fee_id,
+      inplayer_token,
+    };
+
+    const tokenObject = await this.request.getToken();
+
+    return this.request.authenticatedPost(API.subscriptionPlanChange, qs.stringify(body), {
       headers: {
         Authorization: `Bearer ${tokenObject.token}`,
         'Content-Type': 'application/x-www-form-urlencoded',

--- a/src/endpoints/subscription.ts
+++ b/src/endpoints/subscription.ts
@@ -262,7 +262,7 @@ class Subscription extends BaseExtend {
    *     InPlayer.Subscription
    *     .changeSubscriptionPlan({
    *          access_fee_id: 1,
-   *          inplayer_token: S-xxxxx-ST
+   *          inplayer_token: 'S-xxxxx-ST'
    *        }
    *     )
    *     .then(data => console.log(data));

--- a/src/endpoints/subscription.ts
+++ b/src/endpoints/subscription.ts
@@ -9,6 +9,7 @@ import {
   GetDefaultCard,
   SetDefaultCard,
   ChangeSubscriptionPlanRequestBody,
+  ChangeSubscriptionPlanResponse,
 } from '../models/ISubscription';
 import { CommonResponse } from '../models/CommonInterfaces';
 import { ApiConfig, Request } from '../models/Config';
@@ -273,12 +274,13 @@ class Subscription extends BaseExtend {
   }: {
     access_fee_id: number,
     inplayer_token: string,
-   }): Promise<AxiosResponse<CommonResponse>> {
+   }): Promise<AxiosResponse<ChangeSubscriptionPlanResponse>> {
     const body: ChangeSubscriptionPlanRequestBody = {
       access_fee_id,
       inplayer_token,
     };
 
+    console.log('Inside changeSubscriptionPlan')
     const tokenObject = await this.request.getToken();
 
     return this.request.authenticatedPost(API.subscriptionPlanChange, qs.stringify(body), {

--- a/src/endpoints/subscription.ts
+++ b/src/endpoints/subscription.ts
@@ -280,7 +280,6 @@ class Subscription extends BaseExtend {
       inplayer_token,
     };
 
-    console.log('Inside changeSubscriptionPlan')
     const tokenObject = await this.request.getToken();
 
     return this.request.authenticatedPost(API.subscriptionPlanChange, qs.stringify(body), {

--- a/src/models/Config.ts
+++ b/src/models/Config.ts
@@ -73,6 +73,7 @@ export interface ApiEndpoints {
   cancelSubscription: (url: string) => string;
   subscribe: string;
   subscribeV2: string;
+  changeSubscriptionPlan: (access_fee_id: number, inplayer_token: string) => string;
   // Voucher
   getDiscount: string;
   // Restrictions

--- a/src/models/IAsset&Access.ts
+++ b/src/models/IAsset&Access.ts
@@ -34,6 +34,7 @@ export interface Item {
   template_id: number | null;
   created_at: number;
   update_at: number;
+  plan_switch_enabled: boolean;
 }
 
 export interface AccessType {

--- a/src/models/ISubscription.ts
+++ b/src/models/ISubscription.ts
@@ -82,6 +82,11 @@ export interface CreateSubscriptionRequestBody {
     is_gift?: boolean;
 }
 
+export interface ChangeSubscriptionPlanRequestBody {
+    access_fee_id: number;
+    inplayer_token: string;
+}
+
 export interface IdealPaymentRequestBody {
     payment_method: 'ideal';
     access_fee_id: number;
@@ -119,6 +124,10 @@ export interface SetDefaultCardPerCurrencyData {
   currency: string;
 }
 
+export interface ChangeSubscriptionPlanResponse {
+  message: string;
+}
+
 export interface Subscription extends BaseExtend {
     getSubscriptions(
         page?: number,
@@ -131,6 +140,10 @@ export interface Subscription extends BaseExtend {
     createSubscription(
         data: CreateSubscriptionData
     ): Promise<AxiosResponse<CommonResponse>>;
+    changeSubscriptionPlan(
+        access_fee_id: number,
+        inplayer_token: string
+    ): Promise<AxiosResponse<ChangeSubscriptionPlanResponse>>;
     directDebitSubscribe: (
         data: DirectDebitData
       ) => Promise<AxiosResponse<CommonResponse>>;

--- a/src/models/ISubscription.ts
+++ b/src/models/ISubscription.ts
@@ -141,8 +141,7 @@ export interface Subscription extends BaseExtend {
         data: CreateSubscriptionData
     ): Promise<AxiosResponse<CommonResponse>>;
     changeSubscriptionPlan(
-        access_fee_id: number,
-        inplayer_token: string
+        data: ChangeSubscriptionPlanRequestBody
     ): Promise<AxiosResponse<ChangeSubscriptionPlanResponse>>;
     directDebitSubscribe: (
         data: DirectDebitData


### PR DESCRIPTION
## OVERVIEW

Description: A new method for Subscribe called `changeSubscriptionPlan` that performs a switch from the current subscription plan, which can be either a upgrade or a downgrade.

This is part of the work done for the paywall that includes this feature, and related PR's will be linked later on.

Notion card:  [Implement plan switch on Paywall](https://www.notion.so/5010c87fccf5479e946ea7750c549dfe?v=1bc672978c16425c927a0427ed33ef39&p=a3d2186d446441a9941cf19bfd4fd08b) 

## WHERE SHOULD THE REVIEWER START?

_e.g. `/src/Models/Account.js`_

## ANY NEW DEPENDENCIES ADDED?

_List any new dependencies added._

- [ ] Does it work in IE >= 11?
- [ ] _Does it work in other browsers?_

## CHECKLIST

_Be sure all items are_ ✅ _before submitting a PR for review._

- [ ] Verify you bumped the lib version according to [Semantic Versioning Standards](http://semver.org)
- [ ] Verify you updated the CHANGELOG
- [ ] Verify this branch is rebased with the latest master
