### PR TITLE
Added an additional address param used for specific countries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+# [3.13.1] - 16-08-2022
+
+### Added
+
+- Added `address` param in direct debit payments method which is needed for specific coutries
+
 # [3.13.0] - 26-06-2022
 
 ### Added

--- a/index.d.ts
+++ b/index.d.ts
@@ -573,6 +573,7 @@ export interface DefaultCreditCardData {
 export interface DirectDebitMandateData {
   name: string;
   iban: string;
+  address?: string;
 }
 
 export interface DirectDebitChargeData {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inplayer-org/inplayer.js",
-  "version": "3.13.0",
+  "version": "3.13.1",
   "author": "InPlayer",
   "license": "MIT",
   "description": "A Javascript SDK for Inplayer's RESTful API",

--- a/src/endpoints/payment.ts
+++ b/src/endpoints/payment.ts
@@ -638,6 +638,7 @@ class Payment extends BaseExtend {
    * @async
    * @param {string} name The customer's bank full name
    * @param {string} iban The customer's bank IBAN number
+   * @param {string} address The customer's address used for specific countries
    * @example
    *     InPlayer.Payment
    *     .createDirectDebitMandate({
@@ -673,13 +674,16 @@ class Payment extends BaseExtend {
   async createDirectDebitMandate({
     name,
     iban,
+    address,
   }: {
     name: string;
     iban: string;
+    address?: string;
   }): Promise<AxiosResponse<CreateDirectDebitResponse>> {
     const body = {
       name,
       iban,
+      ...(address && { address }),
     };
 
     const tokenObject = await this.request.getToken();

--- a/src/models/IPayment.ts
+++ b/src/models/IPayment.ts
@@ -129,6 +129,7 @@ export interface ConfirmDonationPaymentRequestBody {
 export interface CreateDirectDebitMandateData {
   name: string;
   iban: string;
+  address?: string;
 }
 
 export interface DirectDebitData {
@@ -193,6 +194,7 @@ export interface CreateDirectDebitResponse {
 export interface DirectDebitMandateData {
   name: string;
   iban: string;
+  address?: string;
 }
 
 export interface PurchaseDetails {


### PR DESCRIPTION
## OVERVIEW

An additional (optional) "address" field has been added which is required for the countries specified in the card

Notion card: [Viewer: Add address field on the payment screen when using SEPA](https://www.notion.so/5010c87fccf5479e946ea7750c549dfe?v=1bc672978c16425c927a0427ed33ef39&p=7b0c56233eff4d8a8798836d8e691c85&pm=s)

## WHERE SHOULD THE REVIEWER START?

index.d.ts
src/endpoints/payment.ts
src/models/IPayment.ts

## ANY NEW DEPENDENCIES ADDED?

_List any new dependencies added._

- [ ] Does it work in IE >= 11?
- [ ] _Does it work in other browsers?_

## CHECKLIST

_Be sure all items are_ ✅ _before submitting a PR for review._

- [ ] Verify you bumped the lib version according to [Semantic Versioning Standards](http://semver.org)
- [ ] Verify you updated the CHANGELOG
- [ ] Verify this branch is rebased with the latest master
