### PR TITLE
Corrected "options" type in RegisterField

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "tabWidth": 2,
+  "useTabs": false,
+  "singleQuote": true
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+# [3.13.21] - 10-11-2023
+
+### Changes
+
+- Corrected `options` type in `RegisterField`
+
 # [3.13.20] - 06-11-2023
 
 ### Added

--- a/index.d.ts
+++ b/index.d.ts
@@ -145,9 +145,7 @@ export declare interface ListSocialURLs {
   code: number;
 }
 
-export declare interface GetRegisterFieldOption {
-  [key: string]: string;
-}
+export type RegisterFieldOptions = Record<string, string>;
 
 export declare interface RegisterField {
   id: number;
@@ -157,7 +155,7 @@ export declare interface RegisterField {
   required: boolean;
   default_value: string;
   placeholder: string;
-  options: GetRegisterFieldOption[];
+  options: RegisterFieldOptions;
 }
 
 export interface GetRegisterFieldsResponse {

--- a/src/models/IAccount&Authentication.ts
+++ b/src/models/IAccount&Authentication.ts
@@ -60,7 +60,8 @@ export interface SetNewPasswordData {
   brandingId: number;
 }
 
-export interface ChangePasswordData extends Omit<SetNewPasswordData, 'brandingId'> {
+export interface ChangePasswordData
+  extends Omit<SetNewPasswordData, 'brandingId'> {
   oldPassword: string;
   brandingId?: number;
 }
@@ -129,9 +130,7 @@ export interface ListSocialURLs {
   code: number;
 }
 
-export interface GetRegisterFieldOption {
-  [key: string]: string;
-}
+export type RegisterFieldOptions = Record<string, string>;
 
 export interface RegisterField {
   id: number;
@@ -141,7 +140,7 @@ export interface RegisterField {
   required: boolean;
   default_value: string;
   placeholder: string;
-  options: GetRegisterFieldOption[];
+  options: RegisterFieldOptions;
 }
 
 export interface GetRegisterFieldsResponse {
@@ -208,33 +207,71 @@ export interface Account extends BaseExtend {
   signOut(): Promise<AxiosResponse<undefined>>;
   refreshToken(clientId: string): Promise<AxiosResponse<CreateAccount>>;
   changePassword(data: ChangePasswordData): Promise<AxiosResponse<void>>;
-  requestNewPassword(data: RequestNewPasswordData): Promise<AxiosResponse<CommonResponse>>;
-  setNewPassword(data: SetNewPasswordData, token?: string): Promise<AxiosResponse<void>>;
+  requestNewPassword(
+    data: RequestNewPasswordData
+  ): Promise<AxiosResponse<CommonResponse>>;
+  setNewPassword(
+    data: SetNewPasswordData,
+    token?: string
+  ): Promise<AxiosResponse<void>>;
   getAccountInfo(): Promise<AxiosResponse<AccountData>>;
   updateAccount(data: UpdateAccountData): Promise<AxiosResponse<AccountData>>;
-  exportData(data: Omit<AccountAuthData, 'password'> & { password?: string }): Promise<AxiosResponse<CommonResponse>>;
+  exportData(
+    data: Omit<AccountAuthData, 'password'> & { password?: string }
+  ): Promise<AxiosResponse<CommonResponse>>;
   deleteAccount(data: AccountAuthData): Promise<AxiosResponse<CommonResponse>>;
   getSocialLoginUrls(state: string): Promise<AxiosResponse<ListSocialURLs>>;
-  getRegisterFields(merchantUuid: string): Promise<AxiosResponse<GetRegisterField>>;
-  reportSSOtoken(ssoDomain: string, token: string, deactivate: boolean): Promise<AxiosResponse<any>>;
+  getRegisterFields(
+    merchantUuid: string
+  ): Promise<AxiosResponse<GetRegisterField>>;
+  reportSSOtoken(
+    ssoDomain: string,
+    token: string,
+    deactivate: boolean
+  ): Promise<AxiosResponse<any>>;
   sendPinCode(brandingId?: number): Promise<AxiosResponse<CommonResponse>>;
   validatePinCode(pinCode: string): Promise<AxiosResponse<CommonResponse>>;
-  syncWithExternalAccount(integration: string, itemId: number): Promise<AxiosResponse<AccountProfile>>;
-  updateExternalAccount(integratiion: string, body: Record<string, any>): Promise<AxiosResponse<any>>;
-  loadMerchantRestrictionSettings(merchantUuid: string): Promise<AxiosResponse<RestrictionSettingsData>>;
+  syncWithExternalAccount(
+    integration: string,
+    itemId: number
+  ): Promise<AxiosResponse<AccountProfile>>;
+  updateExternalAccount(
+    integratiion: string,
+    body: Record<string, any>
+  ): Promise<AxiosResponse<any>>;
+  loadMerchantRestrictionSettings(
+    merchantUuid: string
+  ): Promise<AxiosResponse<RestrictionSettingsData>>;
   getFavorites(): Promise<AxiosResponse<CollectionWithCursor<FavoritesData>>>;
   getFavorite(mediaId: string): Promise<AxiosResponse<FavoritesData>>;
   addToFavorites(mediaId: string): Promise<AxiosResponse<FavoritesData>>;
   deleteFromFavorites(mediaId: string): Promise<AxiosResponse<CommonResponse>>;
-  getWatchHistory(args: CollectionWithCursorArgs): Promise<AxiosResponse<CollectionWithCursor<WatchHistory>>>;
+  getWatchHistory(
+    args: CollectionWithCursorArgs
+  ): Promise<AxiosResponse<CollectionWithCursor<WatchHistory>>>;
   getWatchHistoryForItem(mediaId: string): Promise<AxiosResponse<WatchHistory>>;
-  updateWatchHistory(mediaId: string, progress: number): Promise<AxiosResponse<WatchHistory>>;
-  deleteWatchHistoryForItem(mediaId: string): Promise<AxiosResponse<CommonResponse>>;
+  updateWatchHistory(
+    mediaId: string,
+    progress: number
+  ): Promise<AxiosResponse<WatchHistory>>;
+  deleteWatchHistoryForItem(
+    mediaId: string
+  ): Promise<AxiosResponse<CommonResponse>>;
   getProfiles(): Promise<AxiosResponse<ProfilesData>>;
   enterProfile(id: string, pin?: number): Promise<AxiosResponse<ProfilesData>>;
-  createProfile(name: string, adult: boolean, avatar_url?: string, pin?: number): Promise<AxiosResponse<ProfilesData>>;
+  createProfile(
+    name: string,
+    adult: boolean,
+    avatar_url?: string,
+    pin?: number
+  ): Promise<AxiosResponse<ProfilesData>>;
   getProfileDetails(id: string): Promise<AxiosResponse<ProfilesData>>;
-  updateProfile(id: string, name: string, avatar_url?: string, adult?: boolean): Promise<AxiosResponse<ProfilesData>>;
+  updateProfile(
+    id: string,
+    name: string,
+    avatar_url?: string,
+    adult?: boolean
+  ): Promise<AxiosResponse<ProfilesData>>;
   deleteProfile(id: string): Promise<AxiosResponse<ProfilesData>>;
   getFeatureFlags(): Promise<AxiosResponse<FeatureFlagData[]>>;
 }


### PR DESCRIPTION
## OVERVIEW

The `RegisterField.options`property was incorrectly set to array `Record<string, string>[]`. Its correct type is `Record<string, string>`.

**NOTE**: The rest of the changes is just formatting by `prettier`, they're unmodified.

## WHERE SHOULD THE REVIEWER START?

_e.g. `/src/Models/Account.js`_

## ANY NEW DEPENDENCIES ADDED?

_List any new dependencies added._

- [x] Does it work in IE >= 11?
- [x] _Does it work in other browsers?_

## CHECKLIST

_Be sure all items are_ ✅ _before submitting a PR for review._

- [x] Verify you bumped the lib version according to [Semantic Versioning Standards](http://semver.org)
- [x] Verify you updated the CHANGELOG
- [x] Verify this branch is rebased with the latest master
